### PR TITLE
Absolute paths changed to relative paths in ufpa_run (D.Kroon's code Octave)

### DIFF
--- a/ViolaJones_version0b/ufpa_run.m
+++ b/ViolaJones_version0b/ufpa_run.m
@@ -18,6 +18,8 @@
 fileName = 'HaarCascades\haarcascade_frontalface_alt.xml';
 imageFileName = 'Images\1.jpg';
 %imageFileName = 'Images\2.jpg';
+%imageFileName = 'C:/ak/Works/2016_opencv/build3/bin/Debug/photo.jpg';
+%imageFileName = 'C:\ak\Works\2016_opencv\ViolaJones_version0b\Images\1.jpg';
 
 j=find(fileName=='.'); 
 if(~isempty(j))

--- a/ViolaJones_version0b/ufpa_run.m
+++ b/ViolaJones_version0b/ufpa_run.m
@@ -15,15 +15,9 @@
 %XML with new format, obtained from the latest OpenCV:
 %fileName = 'C:/ak/Works/2016_opencv/sources/data/haarcascades/haarcascade_frontalface_alt.xml';
 %XML with old format, from fileexchange:
-
-%Path in my Work's Computer
-fileName = 'C:\Users\Cleverson Nahum\Documents\Cleverson\Octave\ufpa-face-detection\ViolaJones_version0b\HaarCascades\haarcascade_frontalface_alt.xml';
-
-%imageFileName = 'C:/ak/Works/2016_opencv/build3/bin/Debug/photo.jpg';
-%imageFileName = 'C:\ak\Works\2016_opencv\ViolaJones_version0b\Images\1.jpg';
-
-%Path in my Work's Computer
-imageFileName = 'C:\Users\Cleverson Nahum\Documents\Cleverson\Octave\ufpa-face-detection\ViolaJones_version0b\Images\2.jpg';
+fileName = 'HaarCascades\haarcascade_frontalface_alt.xml';
+imageFileName = 'Images\1.jpg';
+%imageFileName = 'Images\2.jpg';
 
 j=find(fileName=='.'); 
 if(~isempty(j))


### PR DESCRIPTION
The paths of 'ufpa_run.m' in the variables 'fileName' and 'ImageFileName' have been replaced by relative paths, not needing more than the paths to be edited by each user to work.
